### PR TITLE
Improve usage experience

### DIFF
--- a/fenna
+++ b/fenna
@@ -294,6 +294,16 @@ v2_configure_target () {
 v2_target () {
   local name="${1}"
 
+  if [[ -z "$name" ]]
+  then
+    if [[ -L ".fenna/target" ]]
+    then
+      basename "$(readlink .fenna/target)"
+    fi
+
+    return
+  fi
+
   if [[ -d ".fenna/targets/${name}" ]]
   then
     if [[ -f ".fenna/targets/${name}/profile" ]] && [[ -f ".fenna/targets/${name}/backend/profile" ]]

--- a/fenna
+++ b/fenna
@@ -500,6 +500,28 @@ v2_plan () {
 
 
 #
+# Usage
+#
+
+usage () {
+  cat <<EOF
+Usage: $(basename "$0") <command> [<args>]
+
+  bootstrap  Configure a new service
+  onboard    Configure profiles for a bootstrapped service
+  migrate    Migrate from fenna v1 to v2
+
+  backends  List available backends
+  targets   List available targets
+
+  target <name>  Select a target or configure a new target
+  init           Run "terraform init" for the current target
+  plan           Run "terraform plan" for the current target
+  apply          Run "terraform apply" for the current target
+EOF
+}
+
+#
 # Dispatch
 #
 
@@ -517,6 +539,7 @@ then
     init) v2_init "${@}" ;;
     plan) v2_plan "${@}" ;;
     apply) apply "${@}" ;;
+    *) usage ;;
   esac
 else
   case "$cmd" in
@@ -526,5 +549,6 @@ else
     init) init "$@" ;;
     plan) plan "$@" ;;
     apply) apply "$@" ;;
+    *) usage ;;
   esac
 fi


### PR DESCRIPTION
This adds a couple of small quality-of-life changes to the tool.

1. Print a usage message listing the available commands when running `fenna` with no arguments or unrecognized arguments. I found I very often had to look up the docs when setting up a new worktree for the first time. This usage message would help to jog the users memory.
2. Print the current target (if set) and exit when running `fenna target`. I found myself often running `fenna target` expecting this behavior and instead it would create a profile named `profile`.

I did my best on the usage message, but feel free to edit it if anything is off.